### PR TITLE
Changed the default numbers for Encryption

### DIFF
--- a/js/bundle.js
+++ b/js/bundle.js
@@ -4911,7 +4911,7 @@ module.exports = EventListener;
         mission:false,
         computer:null,
         downlink:null,
-        version:"0.1.6a",
+        version:"0.1.7a",
         /**
          * jquery entities that are needed for updating
          */


### PR DESCRIPTION
Found a bug in the CPU Task assignation that would cause an infinite loop of a task could not be fit on to any of the CPUs

Also forgot to pull the new version number